### PR TITLE
Core Primitives: Add font weights

### DIFF
--- a/index.json
+++ b/index.json
@@ -79,6 +79,10 @@
     "2.25rem",
     "3rem"
   ],
+  "fontWeight": {
+    "normal": 400,
+    "bold": 700
+  },
   "lineHeight": {
     "none": 1,
     "tight": 1.25,


### PR DESCRIPTION
Adds `fontWeight` values to Core Primitives. This one isn't as fun as shadows.