### PR TITLE
Core Primitives: Add type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,75 @@
+interface Primitives {
+  color: Color
+  space: string[]
+  fontSize: string[]
+  fontWeight: FontWeight
+  lineHeight: LineHeight
+  breakpoint: Breakpoint
+  shadow: string[]
+}
+interface Color {
+  blue: string
+  green: string
+  yellow: string
+  red: string
+  white: string
+  black: string
+  blueLight4: string
+  blueLight3: string
+  blueLight2: string
+  blueLight1: string
+  blueDark1: string
+  blueDark2: string
+  blueDark3: string
+  blueDark4: string
+  greenLight4: string
+  greenLight3: string
+  greenLight2: string
+  greenLight1: string
+  greenDark1: string
+  greenDark2: string
+  greenDark3: string
+  greenDark4: string
+  yellowLight4: string
+  yellowLight3: string
+  yellowLight2: string
+  yellowLight1: string
+  yellowDark1: string
+  yellowDark2: string
+  yellowDark3: string
+  yellowDark4: string
+  redLight4: string
+  redLight3: string
+  redLight2: string
+  redLight1: string
+  redDark1: string
+  redDark2: string
+  redDark3: string
+  redDark4: string
+  gray1: string
+  gray2: string
+  gray3: string
+  gray4: string
+  gray5: string
+  gray6: string
+  gray7: string
+  gray8: string
+}
+interface FontWeight {
+  normal: number
+  bold: number
+}
+interface LineHeight {
+  none: number
+  tight: number
+  normal: number
+  loose: number
+}
+interface Breakpoint {
+  sm: string
+  md: string
+  lg: string
+  xl: string
+}
+declare const primitives: Primitives
+export default primitives

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,13 @@
 interface Primitives {
   color: Color
-  space: string[]
-  fontSize: string[]
+  space: Space
+  fontSize: FontSize
   fontWeight: FontWeight
   lineHeight: LineHeight
   breakpoint: Breakpoint
-  shadow: string[]
+  shadow: Shadow
 }
+
 interface Color {
   blue: string
   green: string
@@ -55,21 +56,38 @@ interface Color {
   gray7: string
   gray8: string
 }
+
+type Space = string[]
+
+type FontSize = string[]
+
 interface FontWeight {
   normal: number
   bold: number
 }
+
 interface LineHeight {
   none: number
   tight: number
   normal: number
   loose: number
 }
+
 interface Breakpoint {
   sm: string
   md: string
   lg: string
   xl: string
 }
+
+type Shadow = string[]
+
+export declare const color: Color
+export declare const space: Space
+export declare const fontSize: FontSize
+export declare const fontWeight: FontWeight
+export declare const lineHeight: LineHeight
+export declare const breakpoint: Breakpoint
+export declare const shadow: Shadow
 declare const primitives: Primitives
 export default primitives

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "0.10.1-0",
+  "version": "0.10.1-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "0.10.0",
+  "version": "0.10.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "0.10.1-0",
+  "version": "0.10.1-1",
   "description": "",
   "main": "index.json",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "0.10.0",
+  "version": "0.10.1-0",
   "description": "",
   "main": "index.json",
   "files": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.10.1-0",
   "description": "",
   "main": "index.json",
+  "types": "index.d.ts",
   "files": [
+    "index.json",
     "index.d.ts",
     "core-primitives.less"
   ],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.json",
   "files": [
-    "*.less"
+    "index.d.ts",
+    "core-primitives.less"
   ],
   "scripts": {
     "build": "node bin/build.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "",
   "main": "index.json",
   "files": [


### PR DESCRIPTION
This pull adds a type definitions file (`index.d.ts`). Now we can use `@core-ds/primitives` in TypeScript files!  

![kapture 2019-02-06 at 15 44 20](https://user-images.githubusercontent.com/4608155/52381419-2f2b4700-2a26-11e9-95c3-fb4d360b07f4.gif)


We'll might want to automate the creation of `index.d.ts` eventually. But at this point, I'm not sure automation is worth the time.