### PR TITLE
core-primitives: expand font and border primitives

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -11,8 +11,8 @@ fs.writeFileSync(
 // GENERATED FILE. DO NOT EDIT.`,
     toLess(primitives),
   ]
-    .map((string) => string + "\n")
-    .join("")
+    .map((string) => string)
+    .join("\n")
 );
 
 function toLess(obj) {
@@ -29,8 +29,7 @@ fs.writeFileSync(
     `:root {`,
     toCssVars(primitives),
     `}`,
-  ]
-    .join("\n")
+  ].join("\n")
 );
 
 function toCssVars(obj) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -78,6 +78,7 @@ type FontSize = string[];
 
 interface FontWeight {
   normal: number;
+  semiBold: number;
   bold: number;
 }
 
@@ -101,6 +102,7 @@ interface BorderRadius {
   sm: string;
   md: string;
   lg: string;
+  xl: string;
   pill: string;
 }
 

--- a/index.json
+++ b/index.json
@@ -99,7 +99,7 @@
   },
   "lineHeight": {
     "none": 1,
-    "base": 1.14286,
+    "base": 1.142857143,
     "tight": 1.25,
     "normal": 1.42857,
     "loose": 2

--- a/index.json
+++ b/index.json
@@ -87,10 +87,14 @@
     "24px",
     "30px",
     "36px",
-    "48px"
+    "48px",
+    "56px",
+    "64px",
+    "72px"
   ],
   "fontWeight": {
     "normal": 400,
+    "semi-bold": 600,
     "bold": 700
   },
   "lineHeight": {
@@ -117,6 +121,7 @@
     "sm": "2px",
     "md": "4px",
     "lg": "8px",
+    "xl": "16px",
     "pill": "999px"
   }
 }


### PR DESCRIPTION
Summary of changes
---
- expands `font-size` options up to 72px
- adds semi-bold `font-weight` option
- adds 16px `border-radius` option

These are for additional styling options seen recently either in issues or in the core design system.

#### QA:
qa_req 0 - these are non-breaking additions

Merge checklist
---

- [ ] Bump the package version by running `npm version [patch | minor | major]` from the command line (if applicable).

> **Note:** In the context of Core Primitives, significant changes to the library or workflow, or removing primitives would be considered a major update, adding or updating primitives would be considered a minor update, and fixing primitives would be considered a patch. Non-code changes (e.g. documentation) do not require a version bump.
