### PR TITLE
Camel Case JSON Keys

### DIFF
--- a/index.json
+++ b/index.json
@@ -71,9 +71,9 @@
   "fontFamily": {
     "inter": "'Inter Var', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif",
     "mono": "'Roboto Mono', 'Monaco', 'Lucida Console', 'Courier New', 'Courier', monospace",
-    "mono-system": "'Monaco', 'Lucida Console', 'Courier New', 'Courier', monospace",
-    "sans-system": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif",
-    "serif-system": "'Georgia', serif"
+    "monoSystem": "'Monaco', 'Lucida Console', 'Courier New', 'Courier', monospace",
+    "sansSystem": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif",
+    "serifSystem": "'Georgia', serif"
   },
   "fontSettings": {
     "inter": "'calt', 'cpsp', 'cv01', 'cv03', 'cv04', 'cv05', 'cv10', 'kern', 'liga'"
@@ -94,7 +94,7 @@
   ],
   "fontWeight": {
     "normal": 400,
-    "semi-bold": 600,
+    "semiBold": 600,
     "bold": 700
   },
   "lineHeight": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,23 @@
 {
   "name": "@core-ds/primitives",
   "version": "1.1.2",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@core-ds/primitives",
+      "version": "1.1.2",
+      "devDependencies": {
+        "lodash.kebabcase": "^4.1.1"
+      }
+    },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
+      "dev": true
+    }
+  },
   "dependencies": {
     "lodash.kebabcase": {
       "version": "4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@core-ds/primitives",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@core-ds/primitives",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "devDependencies": {
         "lodash.kebabcase": "^4.1.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@core-ds/primitives",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@core-ds/primitives",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "devDependencies": {
         "lodash.kebabcase": "^4.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "",
   "main": "index.json",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "",
   "main": "index.json",
   "types": "index.d.ts",


### PR DESCRIPTION
Summary of changes
---
- The keys in index.json need to be camelCase, not kebab-case. The old values do not work when you call them in React, so this is a non-breaking change.
- v1.2.0 already existed so I had to bump the version twice 🤷 

qa_req 0 (since non-breaking)

Merge checklist
---

- [x] Bump the package version by running `npm version [patch | minor | major]` from the command line (if applicable).

> **Note:** In the context of Core Primitives, significant changes to the library or workflow, or removing primitives would be considered a major update, adding or updating primitives would be considered a minor update, and fixing primitives would be considered a patch. Non-code changes (e.g. documentation) do not require a version bump.
