### PR TITLE
Add lato font stack

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -64,6 +64,7 @@ type Space = string[];
 
 interface FontFamily {
   inter: string;
+  lato: string;
   mono: string;
   monoSystem: string;
   sansSystem: string;

--- a/index.json
+++ b/index.json
@@ -70,10 +70,11 @@
   ],
   "fontFamily": {
     "inter": "'Inter Var', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif",
-    "mono": "'Roboto Mono', 'Monaco', 'Lucida Console', 'Courier New', 'Courier', monospace",
-    "monoSystem": "'Monaco', 'Lucida Console', 'Courier New', 'Courier', monospace",
+    "lato": "Lato, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif",
+    "mono": "'Roboto Mono', Monaco, 'Lucida Console', 'Courier New', Courier, monospace",
+    "monoSystem": "Monaco, 'Lucida Console', 'Courier New', Courier, monospace",
     "sansSystem": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif",
-    "serifSystem": "'Georgia', serif"
+    "serifSystem": "Georgia, serif"
   },
   "fontSettings": {
     "inter": "'calt', 'cpsp', 'cv01', 'cv03', 'cv04', 'cv05', 'cv10', 'kern', 'liga'"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@core-ds/primitives",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@core-ds/primitives",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "devDependencies": {
         "lodash.kebabcase": "^4.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "",
   "main": "index.json",
   "types": "index.d.ts",


### PR DESCRIPTION
Summary of changes
---

- Add `Lato` to our font stacks
- Remove unnecessary ticks around single word font names

QA
---

There's no real QA here. This is a non-breaking addition so qa_req 0

Merge checklist
---

- [x] Bump the package version by running `npm version [patch | minor | major]` from the command line (if applicable).

> **Note:** In the context of Core Primitives, significant changes to the library or workflow, or removing primitives would be considered a major update, adding or updating primitives would be considered a minor update, and fixing primitives would be considered a patch. Non-code changes (e.g. documentation) do not require a version bump.
