### PR TITLE
Remove BlinkMacSystemFont from font stacks

### DIFF
--- a/index.json
+++ b/index.json
@@ -69,11 +69,11 @@
     "128px"
   ],
   "fontFamily": {
-    "inter": "'Inter Var', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif",
-    "lato": "Lato, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif",
+    "inter": "'Inter Var', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif",
+    "lato": "Lato, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif",
     "mono": "'Roboto Mono', Monaco, 'Lucida Console', 'Courier New', Courier, monospace",
     "monoSystem": "Monaco, 'Lucida Console', 'Courier New', Courier, monospace",
-    "sansSystem": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif",
+    "sansSystem": "-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif",
     "serifSystem": "Georgia, serif"
   },
   "fontSettings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@core-ds/primitives",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@core-ds/primitives",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "devDependencies": {
         "lodash.kebabcase": "^4.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "",
   "main": "index.json",
   "types": "index.d.ts",


### PR DESCRIPTION
Summary of changes
---

- Remove `BlinkMacSystemFont` from all font stacks due to Chrome bug [here](https://bugs.chromium.org/p/chromium/issues/detail?id=1057654#c35) and [here](https://bugs.chromium.org/p/chromium/issues/detail?id=781344&q=BlinkMacSystemFont&can=1&sort=-modified)

Merge checklist
---

- [x] Bump the package version by running `npm version [patch | minor | major]` from the command line (if applicable).

> **Note:** In the context of Core Primitives, significant changes to the library or workflow, or removing primitives would be considered a major update, adding or updating primitives would be considered a minor update, and fixing primitives would be considered a patch. Non-code changes (e.g. documentation) do not require a version bump.

Non-breaking minor version change so:
qa_req 0