### PR TITLE
Refactor primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ CSS Core Primitives are [globally available](https://github.com/iFixit/ifixit/bl
 ```css
 /* excerpt from core-primitives.css */
 :root {
-  --color-black: #000;
+  --color-black: #11161a;
   --color-white: #fff;
   ...
   --color-blue-500: #3b82f6;
@@ -96,14 +96,13 @@ Follow these steps to get the project setup on your local machine:
 
 ```shell
 # Clone repo
-git clone https://github.com/iFixit/core-primitives.git
-cd core-primitives
+git clone https://github.com/iFixit/core-primitives.git && cd core-primitives
 
 # Install dependencies
 npm install
 ```
 
-## Adding or updating primitives
+# Adding or Updating Primitives
 
 ## 1. Create a new branch
 
@@ -117,27 +116,25 @@ git checkout -b <branch>
 
 Apply your changes to `index.json`, and keep `index.d.ts` in sync.
 
-## 3. Open a pull request
+## 3. Test your build
+
+Run `npm run build` and verify `core-primitives.css` and `core-primitives.less` are correct.
+
+## 4. Open a pull request
 
 Use GitHub to [create a pull request](https://help.github.com/en/desktop/contributing-to-projects/creating-a-pull-request) for your branch.
 
-## 4. Bump the package version
+## 5. Bump the package version
 
 After your pull request has been approved, bump the package version by running:
 
 ```shell
-npm version [patch | minor | major]
+npm version [major | minor | patch]
 ```
 
-[`npm version`](https://docs.npmjs.com/cli/version.html) will bump the version and write the new data back to `package.json` and `package-lock.json`. It will also create and push a version commit and tag.
+Running [`npm version`](https://docs.npmjs.com/cli/version.html) will build, bump the version, and write the new data to `package.json` and `package-lock.json`. It will also create and push a version commit and tag.
 
 > **Note:** In the context of `@core-ds/primitives`, significant changes to the library or workflow, or removing primitives would be considered a major update, adding or updating primitives would be considered a minor update, and fixing primitives would be considered a patch. Non-code changes (e.g. documentation) do not require a version bump.
-
-## 5. Build Package
-
-```shell
-npm run build
-```
 
 ## 6. Publish to NPM
 

--- a/bin/build.js
+++ b/bin/build.js
@@ -1,8 +1,15 @@
+"use strict";
+
 const fs = require("fs");
 const path = require("path");
-const kebabCase = require("kebab-case");
-const { version } = require("../package.json");
 const primitives = require("../index.json");
+const version = process.env.npm_package_version;
+
+function kebabCase(str) {
+  return str.replace(/[A-Z\u00C0-\u00D6\u00D8-\u00DE]/g, function (match) {
+    return "-" + match.toLowerCase();
+  });
+}
 
 // LESS
 fs.writeFileSync(
@@ -12,7 +19,7 @@ fs.writeFileSync(
 // GENERATED FILE. DO NOT EDIT.
 `,
     toLess(primitives),
-``
+    ``,
   ]
     .map((string) => string)
     .join("\n")
@@ -31,6 +38,7 @@ fs.writeFileSync(
     `/* Core Primitives v${version} */
 /* GENERATED FILE. DO NOT EDIT. */
 
+:host,
 :root {`,
     toCss(primitives),
     `}

--- a/bin/build.js
+++ b/bin/build.js
@@ -5,6 +5,7 @@ const path = require("path");
 const primitives = require("../index.json");
 const version = process.env.npm_package_version;
 
+// Extracted from https://github.com/joakimbeng/kebab-case/blob/master/index.js
 function kebabCase(str) {
   return str.replace(/[A-Z\u00C0-\u00D6\u00D8-\u00DE]/g, function (match) {
     return "-" + match.toLowerCase();

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,11 +7,13 @@ interface Primitives {
   fontWeight: FontWeight;
   lineHeight: LineHeight;
   breakpoint: Breakpoint;
+  minBreakpoint: MinBreakpoint;
   shadow: Shadow;
   borderRadius: BorderRadius;
+  transition: Transition;
 }
 
-interface ColorValue {
+type ColorValue = {
   "50": string;
   "100": string;
   "200": string;
@@ -22,10 +24,21 @@ interface ColorValue {
   "700": string;
   "800": string;
   "900": string;
-}
+};
+
+type BreakpointValue = {
+  sm: string;
+  md: string;
+  lg: string;
+  xl: string;
+};
 
 interface ColorValueBlue extends ColorValue {
-  "ifixit": string;
+  ifixit: string;
+}
+
+interface ColorValueRed extends ColorValue {
+  dozuki: string;
 }
 
 interface Color {
@@ -47,13 +60,13 @@ interface Color {
   yellow: ColorValue;
   amber: ColorValue;
   orange: ColorValue;
-  red: ColorValue;
+  red: ColorValueRed;
   gray: ColorValue;
 }
 
 type Space = string[];
 
-interface FontFamily {
+type FontFamily = {
   arialBlack: string;
   inter: string;
   lato: string;
@@ -61,11 +74,11 @@ interface FontFamily {
   monoSystem: string;
   sansSystem: string;
   serifSystem: string;
-}
+};
 
-interface FontSettings {
+type FontSettings = {
   inter: string;
-}
+};
 
 type FontSize = {
   sm: string;
@@ -80,37 +93,49 @@ type FontSize = {
   "7xl": string;
   "8xl": string;
   "9xl": string;
-}
+};
 
-interface FontWeight {
+type FontWeight = {
   normal: number;
   semiBold: number;
   bold: number;
-}
+};
 
-interface LineHeight {
+type LineHeight = {
   none: number;
   tight: number;
   normal: number;
   loose: number;
-}
+};
 
-interface Breakpoint {
+type Breakpoint = BreakpointValue;
+
+type MinBreakpoint = BreakpointValue;
+
+type Shadow = {
   sm: string;
   md: string;
   lg: string;
   xl: string;
-}
+  "2xl": string;
+};
 
-type Shadow = string[];
-
-interface BorderRadius {
+type BorderRadius = {
   sm: string;
   md: string;
   lg: string;
   xl: string;
   pill: string;
-}
+};
+
+type Transition = {
+  "100": string;
+  "150": string;
+  "200": string;
+  "250": string;
+  "300": string;
+  default: string;
+};
 
 export declare const color: Color;
 export declare const space: Space;
@@ -120,7 +145,9 @@ export declare const fontSize: FontSize;
 export declare const fontWeight: FontWeight;
 export declare const lineHeight: LineHeight;
 export declare const breakpoint: Breakpoint;
+export declare const minBreakpoint: MinBreakpoint;
 export declare const shadow: Shadow;
 export declare const borderRadius: BorderRadius;
-declare const primitives: Primitives;
+export declare const transition: Transition;
+export declare const primitives: Primitives;
 export default primitives;

--- a/index.json
+++ b/index.json
@@ -1,6 +1,6 @@
 {
   "color": {
-    "black": "#000",
+    "black": "#11161a",
     "white": "#fff",
     "rose": {
       "50": "#fff1f2",
@@ -85,7 +85,7 @@
       "700": "#1d4ed8",
       "800": "#1e40af",
       "900": "#1e3a8a",
-      "ifixit": "#1975F1"
+      "ifixit": "#1975f1"
     },
     "lightBlue": {
       "50": "#f0f9ff",
@@ -205,7 +205,8 @@
       "600": "#dc2626",
       "700": "#b91c1c",
       "800": "#991b1b",
-      "900": "#7f1d1d"
+      "900": "#7f1d1d",
+      "dozuki": "#dd4124"
     },
     "gray": {
       "50": "#f9fafb",
@@ -280,18 +281,32 @@
     "lg": "1000px",
     "xl": "1200px"
   },
-  "shadow": [
-    "0 0 1px rgba(17, 22, 26, 0.2)",
-    "0 1px 2px rgba(17, 22, 26, 0.1), 0 2px 4px rgba(17, 22, 26, 0.1)",
-    "0 1px 2px rgba(17, 22, 26, 0.1), 0 4px 8px rgba(17, 22, 26, 0.1)",
-    "0 2px 4px rgba(17, 22, 26, 0.1), 0 8px 16px rgba(17, 22, 26, 0.2)",
-    "0 4px 8px rgba(17, 22, 26, 0.1), 0 16px 32px rgba(17, 22, 26, 0.2)"
-  ],
+  "minBreakpoint": {
+    "sm": "@media (min-width: 576px)",
+    "md": "@media (min-width: 768px)",
+    "lg": "@media (min-width: 1000px)",
+    "xl": "@media (min-width: 1200px)"
+  },
+  "shadow": {
+    "sm": "0 0 1px rgba(17, 22, 26, 0.2)",
+    "md": "0 1px 2px rgba(17, 22, 26, 0.1), 0 2px 4px rgba(17, 22, 26, 0.1)",
+    "lg": "0 1px 2px rgba(17, 22, 26, 0.1), 0 4px 8px rgba(17, 22, 26, 0.1)",
+    "xl": "0 2px 4px rgba(17, 22, 26, 0.1), 0 8px 16px rgba(17, 22, 26, 0.2)",
+    "2xl": "0 4px 8px rgba(17, 22, 26, 0.1), 0 16px 32px rgba(17, 22, 26, 0.2)"
+  },
   "borderRadius": {
     "sm": "2px",
     "md": "4px",
     "lg": "8px",
     "xl": "16px",
     "pill": "999em"
+  },
+  "transition": {
+    "100": "100ms ease-in-out",
+    "150": "150ms ease-in-out",
+    "200": "200ms ease-in-out",
+    "250": "250ms ease-in-out",
+    "300": "300ms ease-in-out",
+    "default": "150ms ease-in-out"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@core-ds/primitives",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@core-ds/primitives",
-      "version": "2.3.0"
+      "version": "2.4.0"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,24 +6,7 @@
   "packages": {
     "": {
       "name": "@core-ds/primitives",
-      "version": "2.3.0",
-      "devDependencies": {
-        "kebab-case": "^1.0.1"
-      }
-    },
-    "node_modules/kebab-case": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.1.tgz",
-      "integrity": "sha512-txPHx6nVLhv8PHGXIlAk0nYoh894SpAqGPXNvbg2hh8spvHXIah3+vT87DLoa59nKgC6scD3u3xAuRIgiMqbfQ==",
-      "dev": true
-    }
-  },
-  "dependencies": {
-    "kebab-case": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.1.tgz",
-      "integrity": "sha512-txPHx6nVLhv8PHGXIlAk0nYoh894SpAqGPXNvbg2hh8spvHXIah3+vT87DLoa59nKgC6scD3u3xAuRIgiMqbfQ==",
-      "dev": true
+      "version": "2.3.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
   ],
   "scripts": {
     "build": "node bin/build.js",
+    "version": "npm run build",
     "postversion": "git push && git push --tags"
-  },
-  "devDependencies": {
-    "kebab-case": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "",
   "main": "index.json",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build": "node bin/build.js",
-    "version": "npm run build",
+    "preversion": "npm run build",
     "postversion": "git push && git push --tags"
   }
 }


### PR DESCRIPTION
Summary of changes
---

1. change `interface` to `type`
2. add `minBreakpoint` primitives
3. add `transition` primitives
4. change `black` value from `#000` to `#11161a`
5. remove `kabab-case` package, inline function instead
6. run npm build script `preversion`
7. bump to `2.4.0`

First step towards completing https://github.com/iFixit/ifixit/issues/40436, with a few improvements thrown in for good measure.

qa_req 0


Merge checklist
---

- [x] Bump the package version by running `npm version [patch | minor | major]` from the command line (if applicable).

> **Note:** In the context of Core Primitives, significant changes to the library or workflow, or removing primitives would be considered a major update, adding or updating primitives would be considered a minor update, and fixing primitives would be considered a patch. Non-code changes (e.g. documentation) do not require a version bump.
