### PR TITLE
Shadow primitives back to an object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -112,13 +112,7 @@ type Breakpoint = BreakpointValue;
 
 type MinBreakpoint = BreakpointValue;
 
-type Shadow = {
-  sm: string;
-  md: string;
-  lg: string;
-  xl: string;
-  "2xl": string;
-};
+type Shadow = string[];
 
 type BorderRadius = {
   sm: string;

--- a/index.json
+++ b/index.json
@@ -287,13 +287,13 @@
     "lg": "@media (min-width: 1000px)",
     "xl": "@media (min-width: 1200px)"
   },
-  "shadow": {
-    "sm": "0 0 1px rgba(17, 22, 26, 0.2)",
-    "md": "0 1px 2px rgba(17, 22, 26, 0.1), 0 2px 4px rgba(17, 22, 26, 0.1)",
-    "lg": "0 1px 2px rgba(17, 22, 26, 0.1), 0 4px 8px rgba(17, 22, 26, 0.1)",
-    "xl": "0 2px 4px rgba(17, 22, 26, 0.1), 0 8px 16px rgba(17, 22, 26, 0.2)",
-    "2xl": "0 4px 8px rgba(17, 22, 26, 0.1), 0 16px 32px rgba(17, 22, 26, 0.2)"
-  },
+  "shadow": [
+    "0 0 1px rgba(17, 22, 26, 0.2)",
+    "0 1px 2px rgba(17, 22, 26, 0.1), 0 2px 4px rgba(17, 22, 26, 0.1)",
+    "0 1px 2px rgba(17, 22, 26, 0.1), 0 4px 8px rgba(17, 22, 26, 0.1)",
+    "0 2px 4px rgba(17, 22, 26, 0.1), 0 8px 16px rgba(17, 22, 26, 0.2)",
+    "0 4px 8px rgba(17, 22, 26, 0.1), 0 16px 32px rgba(17, 22, 26, 0.2)"
+  ],
   "borderRadius": {
     "sm": "2px",
     "md": "4px",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@core-ds/primitives",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@core-ds/primitives",
-      "version": "2.4.0"
+      "version": "2.4.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "",
   "main": "index.json",
   "types": "index.d.ts",


### PR DESCRIPTION
Summary of changes
---

Revert breaking `shadow` change in #29 to avoid unnecessary code changes.

cr_req 1
qa_req 0

Merge checklist
---

- [x] Bump the package version by running `npm version [patch | minor | major]` from the command line (if applicable).

> **Note:** In the context of Core Primitives, significant changes to the library or workflow, or removing primitives would be considered a major update, adding or updating primitives would be considered a minor update, and fixing primitives would be considered a patch. Non-code changes (e.g. documentation) do not require a version bump.
