### PR TITLE
Primitives: Fix LESS min breakpoint entries

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -27,7 +27,7 @@ fs.writeFileSync(
 );
 
 function toLess(obj) {
-  return Object.entries(flatten(obj))
+  return Object.entries(flattenLess(obj))
     .map(([key, value]) => `@${key}: ${value};`)
     .join("\n");
 }
@@ -58,6 +58,34 @@ function flatten(obj) {
     {},
     ...Object.entries(obj).map(([key, value]) => {
       if (typeof value === "object") {
+        return Object.entries(flatten(value)).reduce(
+          (acc, entry) => ({
+            ...acc,
+            [`${kebabCase(key)}-${kebabCase(entry[0])}`]: entry[1],
+          }),
+          {}
+        );
+      } else {
+        return { [kebabCase(key)]: value };
+      }
+    })
+  );
+}
+
+function flattenLess(obj) {
+  return Object.assign(
+    {},
+    ...Object.entries(obj).map(([key, value]) => {
+      // escape LESS minBreakpoint entries
+      if (typeof value === "object" && key === "minBreakpoint") {
+        return Object.entries(flatten(value)).reduce(
+          (acc, entry) => ({
+            ...acc,
+            [`${kebabCase(key)}-${kebabCase(entry[0])}`]: `~"${entry[1]}"`,
+          }),
+          {}
+        );
+      } else if (typeof value === "object") {
         return Object.entries(flatten(value)).reduce(
           (acc, entry) => ({
             ...acc,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@core-ds/primitives",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@core-ds/primitives",
-      "version": "2.4.1"
+      "version": "2.4.2"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@core-ds/primitives",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@core-ds/primitives",
-      "version": "2.4.0"
+      "version": "2.4.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build": "node bin/build.js",
-    "preversion": "npm run build",
-    "postversion": "npm run build && git push && git push --tags"
+    "version": "npm run build",
+    "postversion": "git push && git push --tags"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "",
   "main": "index.json",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "",
   "main": "index.json",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "scripts": {
     "build": "node bin/build.js",
     "preversion": "npm run build",
-    "postversion": "git push && git push --tags"
+    "postversion": "npm run build && git push && git push --tags"
   }
 }


### PR DESCRIPTION
Summary of changes
---

`2.4.1` introduced a LESS bug with the newly minted `minBreakpoint` primitives. This PR fixes the issue by escaping only those entries in https://github.com/iFixit/core-primitives/commit/2a9a823aaa6782f76ff0e7a1f2697bccca23fd96

Now the result is:

```less
@min-breakpoint-sm: ~"@media (min-width: 576px)";
```

QA Notes
---

Screenshot of the built LESS file for confirmation:

![CleanShot 2022-04-14 at 13 39 20@2x](https://user-images.githubusercontent.com/1634505/163471843-991bf56e-e2ed-49b6-a0ab-fceff293c618.png)

Existing 2.4.1 primitives version (lines 234-237):
https://unpkg.com/browse/@core-ds/primitives@2.4.1/core-primitives.less

and the copy/pasta existing values to see the error highlight in my IDE:
![CleanShot 2022-04-14 at 13 44 48@2x](https://user-images.githubusercontent.com/1634505/163472417-ab1298e3-891c-4c31-961d-d64b7a821735.png)


Merge checklist
---

- [x] Bump the package version by running `npm version [patch | minor | major]` from the command line (if applicable).

> **Note:** In the context of Core Primitives, significant changes to the library or workflow, or removing primitives would be considered a major update, adding or updating primitives would be considered a minor update, and fixing primitives would be considered a patch. Non-code changes (e.g. documentation) do not require a version bump.
