### PR TITLE
Named exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,16 @@
+import json from './index.json';
+
+export const color = json.color;
+export const space = json.space;
+export const fontFamily = json.fontFamily;
+export const fontSettings = json.fontSettings;
+export const fontSize = json.fontSize;
+export const fontWeight = json.fontWeight;
+export const lineHeight = json.lineHeight;
+export const breakpoint = json.breakpoint;
+export const minBreakpoint = json.minBreakpoint;
+export const shadow = json.shadow;
+export const borderRadius = json.borderRadius;
+export const transition = json.transition;
+export const primitives = json;
+export default json;

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "@core-ds/primitives",
   "version": "2.4.3",
   "description": "",
-  "main": "index.json",
+  "main": "index.js",
   "types": "index.d.ts",
   "files": [
+    "index.js",
     "index.json",
     "index.d.ts",
     "core-primitives.less",


### PR DESCRIPTION
Summary of changes
---
Alter our typescript types to be a real typescript version of the index.json with notably *named* exports instead of a single default export as we get with the json.

We've been getting tons of warnings from eslint because we were doing `import {color} from '@core-ds/primitives'` and webpack was synthesizing the named exports and warned us about it.


Merge checklist
---

- [ ] Bump the package version by running `npm version [patch | minor | major]` from the command line (if applicable).