### PR TITLE
Update primitive breakpoints

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,7 @@ type BreakpointValue = {
   md: string;
   lg: string;
   xl: string;
+  "2xl": string;
 };
 
 interface ColorValueBlue extends ColorValue {

--- a/index.json
+++ b/index.json
@@ -239,15 +239,11 @@
   ],
   "fontFamily": {
     "arialBlack": "'Arial Black', 'Arial Bold', Gadget, sans-serif",
-    "inter": "Inter, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif",
     "lato": "Lato, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif",
     "mono": "'Roboto Mono', Monaco, 'Lucida Console', 'Courier New', Courier, monospace",
     "monoSystem": "Monaco, 'Lucida Console', 'Courier New', Courier, monospace",
     "sansSystem": "-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif",
     "serifSystem": "Georgia, serif"
-  },
-  "fontSettings": {
-    "inter": "'calt', 'cpsp', 'cv01', 'cv03', 'cv04', 'cv05', 'cv10', 'kern', 'liga'"
   },
   "fontSize": {
     "sm": "12px",

--- a/index.json
+++ b/index.json
@@ -278,14 +278,16 @@
   "breakpoint": {
     "sm": "576px",
     "md": "768px",
-    "lg": "1000px",
-    "xl": "1200px"
+    "lg": "1028px",
+    "xl": "1280px",
+    "2xl": "1536px"
   },
   "minBreakpoint": {
     "sm": "@media (min-width: 576px)",
     "md": "@media (min-width: 768px)",
-    "lg": "@media (min-width: 1000px)",
-    "xl": "@media (min-width: 1200px)"
+    "lg": "@media (min-width: 1028px)",
+    "xl": "@media (min-width: 1280px)",
+    "2xl": "@media (min-width: 1536px)"
   },
   "shadow": [
     "0 0 1px rgba(17, 22, 26, 0.2)",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@core-ds/primitives",
-  "version": "2.4.5",
+  "version": "2.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@core-ds/primitives",
-      "version": "2.4.5"
+      "version": "2.5.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "2.4.5",
+  "version": "2.5.0",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Summary of changes
---

Rich found an issue when trying to use the `2xl` primitive breakpoint in the Chakra theme. We don't have one, and we import the breakpoint object directly breaking the Chakra `useBreakpointValue` hook. Tailwind was a big inspiration for Chakra theme tokens, so I plucked their `2xl` value of `1536px`.

While I was there, I noticed that our previous `lg` and `xl` are pretty outdated. They look like old Boostrap values, but they don't match current screen sizes. I converted those over to more standard sizes as well.

There's also no sense in keeping our Inter font values since it's very unlikely we will ever use them.

- [update breakpoints to match Tailwind](https://github.com/iFixit/core-primitives/commit/dd8e16d7c760da5570b5e04cd157383c3fdcf84d)
- [remove stagnant inter values](https://github.com/iFixit/core-primitives/commit/60849958c2fdf0529df7db81124259273d7707d7)

qa_req 0

Merge checklist
---

- [x] Bump the package version by running `npm version [patch | minor | major]` from the command line (if applicable).

> **Note:** In the context of Core Primitives, significant changes to the library or workflow, or removing primitives would be considered a major update, adding or updating primitives would be considered a minor update, and fixing primitives would be considered a patch. Non-code changes (e.g. documentation) do not require a version bump.
