### PR TITLE
System Font Stacks: update to match GitHub

### DIFF
--- a/index.json
+++ b/index.json
@@ -239,7 +239,7 @@
   ],
   "fontFamily": {
     "arialBlack": "'Arial Black', 'Arial Bold', Gadget, sans-serif",
-    "lato": "Lato, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif",
+    "lato": "Lato, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
     "mono": "'Roboto Mono', Monaco, 'Lucida Console', 'Courier New', Courier, monospace",
     "monoSystem": "ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace",
     "sansSystem": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",

--- a/index.json
+++ b/index.json
@@ -241,8 +241,8 @@
     "arialBlack": "'Arial Black', 'Arial Bold', Gadget, sans-serif",
     "lato": "Lato, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif",
     "mono": "'Roboto Mono', Monaco, 'Lucida Console', 'Courier New', Courier, monospace",
-    "monoSystem": "Monaco, 'Lucida Console', 'Courier New', Courier, monospace",
-    "sansSystem": "-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif",
+    "monoSystem": "ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace",
+    "sansSystem": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
     "serifSystem": "Georgia, serif"
   },
   "fontSize": {

--- a/index.json
+++ b/index.json
@@ -239,10 +239,10 @@
   ],
   "fontFamily": {
     "arialBlack": "'Arial Black', 'Arial Bold', Gadget, sans-serif",
-    "lato": "Lato, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', 'Noto Sans', 'Liberation Sans', Arial, sans-serif",
-    "mono": "'Roboto Mono', Monaco, 'Lucida Console', 'Courier New', Courier, monospace",
+    "lato": "Lato, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
+    "mono": "'Roboto Mono', ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace",
     "monoSystem": "ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace",
-    "sansSystem": "system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', 'Noto Sans', 'Liberation Sans', Arial, sans-serif",
+    "sansSystem": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
     "serifSystem": "Georgia, serif"
   },
   "fontSize": {

--- a/index.json
+++ b/index.json
@@ -239,10 +239,10 @@
   ],
   "fontFamily": {
     "arialBlack": "'Arial Black', 'Arial Bold', Gadget, sans-serif",
-    "lato": "Lato, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
+    "lato": "Lato, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', 'Noto Sans', 'Liberation Sans', Arial, sans-serif",
     "mono": "'Roboto Mono', Monaco, 'Lucida Console', 'Courier New', Courier, monospace",
     "monoSystem": "ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace",
-    "sansSystem": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
+    "sansSystem": "system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', 'Noto Sans', 'Liberation Sans', Arial, sans-serif",
     "serifSystem": "Georgia, serif"
   },
   "fontSize": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@core-ds/primitives",
-  "version": "2.5.0",
+  "version": "2.5.1-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@core-ds/primitives",
-      "version": "2.5.0"
+      "version": "2.5.1-rc.0"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@core-ds/primitives",
-  "version": "2.5.1-rc.0",
+  "version": "2.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@core-ds/primitives",
-      "version": "2.5.1-rc.0"
+      "version": "2.5.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "2.5.0",
+  "version": "2.5.1-rc.0",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "2.5.1-rc.0",
+  "version": "2.5.1",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
See some analysis by Federico here: https://github.com/iFixit/react-commerce/pull/626#issuecomment-1222652071

As well as some additional references:
- https://bitsofco.de/the-new-system-font-stack/ (2016 - very specific
  on the -apple-system/BlinkMacSystemFont distinction)
- https://markdotto.com/2018/02/07/github-system-fonts/ (2018)
- https://medium.com/towards-more-beautiful-web-typography/survey-system-font-stack-5f73a3b39776 (2020)
- https://css-tricks.com/snippets/css/system-font-stack/ (2022)
- https://make.wordpress.org/core/2016/07/07/native-fonts-in-4-6/ (2016)
- https://qwtel.com/posts/software/the-monospaced-system-ui-css-font-stack/#fn:10 (2020)

Merge checklist
---

- [ ] Bump the package version by running `npm version [patch | minor | major]` from the command line (if applicable).

> **Note:** In the context of Core Primitives, significant changes to the library or workflow, or removing primitives would be considered a major update, adding or updating primitives would be considered a minor update, and fixing primitives would be considered a patch. Non-code changes (e.g. documentation) do not require a version bump.
