### PR TITLE
Fonts: Remove `Liberation Mono` from mono font stacks

### DIFF
--- a/index.json
+++ b/index.json
@@ -321,13 +321,13 @@
     "128px"
   ],
   "fontFamily": {
-    "arialBlack": "'Arial Black', 'Arial Bold', Gadget, sans-serif",
-    "lato": "Lato, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
-    "mono": "'Roboto Mono', ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace",
-    "monoSystem": "ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace",
-    "sansSystem": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
-    "serifSystem": "Georgia, serif"
-  },
+		"arialBlack": "'Arial Black', 'Arial Bold', Gadget, sans-serif",
+		"lato": "Lato, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
+		"mono": "'Roboto Mono', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace",
+		"monoSystem": "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace",
+		"sansSystem": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
+		"serifSystem": "Georgia, serif"
+	},
   "fontSize": {
     "sm": "12px",
     "md": "14px",

--- a/index.json
+++ b/index.json
@@ -321,13 +321,13 @@
     "128px"
   ],
   "fontFamily": {
-		"arialBlack": "'Arial Black', 'Arial Bold', Gadget, sans-serif",
-		"lato": "Lato, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
-		"mono": "'Roboto Mono', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace",
-		"monoSystem": "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace",
-		"sansSystem": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
-		"serifSystem": "Georgia, serif"
-	},
+    "arialBlack": "'Arial Black', 'Arial Bold', Gadget, sans-serif",
+    "lato": "Lato, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
+    "mono": "'Roboto Mono', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace",
+    "monoSystem": "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace",
+    "sansSystem": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
+    "serifSystem": "Georgia, serif"
+  },
   "fontSize": {
     "sm": "12px",
     "md": "14px",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@core-ds/primitives",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@core-ds/primitives",
-      "version": "2.5.1"
+      "version": "2.5.2"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@core-ds/primitives",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Overview
---

`Liberation Mono` is causing vertical alignment issues that we cannot control with CSS (I tried everything):

<details>
  <summary>Native Linux Video</summary>

https://github.com/iFixit/core-primitives/assets/1634505/12b8cebd-cfb4-4e64-9e9d-ad0a59e0d97a

</details>

More on the font: https://en.wikipedia.org/wiki/Liberation_fonts

Summary of changes
---

1. [remove Liberation Mono from mono font stacks](https://github.com/iFixit/core-primitives/commit/acf8ee9b4e8d7b0ca76337101ce10ceb5b0b50cb)

Merge checklist
---

- [x] Bump the package version by running `npm version [patch | minor | major]` from the command line (if applicable).

> **Note:** In the context of Core Primitives, significant changes to the library or workflow, or removing primitives would be considered a major update, adding or updating primitives would be considered a minor update, and fixing primitives would be considered a patch. Non-code changes (e.g. documentation) do not require a version bump.
